### PR TITLE
beasor evol_type

### DIFF
--- a/cosmic/src/const_bse.h
+++ b/cosmic/src/const_bse.h
@@ -24,9 +24,9 @@
       REAL*8 zsun
       COMMON /METVARS/ zsun
       REAL*8 neta,bwind,hewind,beta,xi,acc2,epsnov,windflag
-      REAL*8 eddfac,gamma
+      REAL*8 eddfac,gamma,beasor
       COMMON /WINDVARS/ neta,bwind,hewind,beta,xi,acc2,epsnov,
-     &                  eddfac,gamma,windflag
+     &                  eddfac,gamma,windflag,beasor
       REAL*8 alpha1,lambdaf
       REAL*8 qcrit_array(16)
       COMMON /CEVARS/ qcrit_array,alpha1,lambdaf

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -953,7 +953,6 @@ component.
                rlperi = 0.d0
                dmr(k) = mlwind(kstar(k),lumin(k),rad(k),mass(k),
      &                         massc(k),rlperi,z,massi(k))
-               WRITE(*,*)beasor_on, beasor
                if(beasor.eq.1.0.and.beasor_on.eq.0.d0)then
                   beasor_on = 1.d0
                   evolve_type = 17
@@ -2755,7 +2754,6 @@ component.
                rlperi = rol(k)*(1.d0-ecc)
                dmr(k) = mlwind(kstar(k),lumin(k),radx(k),
      &                         mass(k),massc(k),rlperi,z,massi(k))
-               WRITE(*,*)beasor_on, beasor
                if(beasor_on.eq.0.d0.and.beasor.eq.1.d0)then
                   beasor_on = 1.d0
                   evolve_type = 17

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -213,7 +213,7 @@
       PARAMETER(kw3=619.2d0,wsun=9.46d+07,wx=9.46d+08)
       LOGICAL output
 *
-      REAL*8 qc_fixed
+      REAL*8 qc_fixed, beasor_on
       LOGICAL switchedCE,disrupt
 
 Cf2py intent(in) kstar
@@ -273,6 +273,9 @@ Cf2py intent(out) kick_info_out
       twopi = 2.d0*ACOS(-1.d0)
 
 
+* stars don't start out in RSG:
+      beasor_on = 0.0
+      beasor = 0.0
 * disrupt tracks if system get disrupted by a SN during the common
 * envelope
       disrupt = .false.
@@ -526,6 +529,74 @@ component.
                rlperi = rol(k)*(1.d0-ecc)
                dmr(k) = mlwind(kstar(k),lumin(k),rad(k),mass(k),
      &                         massc(k),rlperi,z,massi(k))
+               WRITE(*,*)beasor_on, beasor
+               if(beasor_on.eq.0.d0.and.beasor.eq.1.d0)then
+                  beasor_on = 1.d0
+                  evolve_type = 17
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                       (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                       (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                      b01_bcm = 0.d0
+                   elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                      b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
+
+               if(beasor.eq.0.d0.and.beasor_on.eq.1.d0)then
+                  beasor_on = 0.d0
+                  evolve_type = 18
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                      (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                      (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                     b01_bcm = 0.d0
+                  elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                     b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
 *
 * Calculate how much of wind mass loss from companion will be
 * accreted (Boffin & Jorissen, A&A 1988, 205, 155).
@@ -882,6 +953,74 @@ component.
                rlperi = 0.d0
                dmr(k) = mlwind(kstar(k),lumin(k),rad(k),mass(k),
      &                         massc(k),rlperi,z,massi(k))
+               WRITE(*,*)beasor_on, beasor
+               if(beasor.eq.1.0.and.beasor_on.eq.0.d0)then
+                  beasor_on = 1.d0
+                  evolve_type = 17
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                       (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                       (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                      b01_bcm = 0.d0
+                   elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                      b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
+
+               if(beasor.eq.0.and.beasor_on.eq.1.d0)then
+                  beasor_on = 0.d0
+                  evolve_type = 18
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                      (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                      (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                     b01_bcm = 0.d0
+                  elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                     b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
             else
                dmr(k) = 0.d0
             endif
@@ -2616,6 +2755,74 @@ component.
                rlperi = rol(k)*(1.d0-ecc)
                dmr(k) = mlwind(kstar(k),lumin(k),radx(k),
      &                         mass(k),massc(k),rlperi,z,massi(k))
+               WRITE(*,*)beasor_on, beasor
+               if(beasor_on.eq.0.d0.and.beasor.eq.1.d0)then
+                  beasor_on = 1.d0
+                  evolve_type = 17
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                       (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                       (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                      b01_bcm = 0.d0
+                   elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                      b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
+
+               if(beasor.eq.0.and.beasor_on.eq.1.d0)then
+                  beasor_on = 0.d0
+                  evolve_type = 18
+                  teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                      (rad(1)**2.d0))**(1.d0/4.d0))
+                  teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                      (rad(2)**2.d0))**(1.d0/4.d0))
+                  if(B_0(1).eq.0.d0)then !PK.
+                     b01_bcm = 0.d0
+                  elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                     b01_bcm = B_0(1)
+                  else
+                     b01_bcm = B(1)
+                  endif
+                  if(B_0(2).eq.0.d0)then
+                     b02_bcm = 0.d0
+                  elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                     b02_bcm = B_0(2)
+                  else
+                     b02_bcm = B(2)
+                  endif
+                  CALL writebpp(jp,tphys,evolve_type,
+     &                          mass(1),mass(2),kstar(1),kstar(2),
+     &                         sep,tb,ecc,rrl1,rrl2,
+     &                         aj(1),aj(2),tms(1),tms(2),
+     &                         massc(1),massc(2),rad(1),rad(2),
+     &                         mass0(1),mass0(2),lumin(1),lumin(2),
+     &                         teff1,teff2,radc(1),radc(2),
+     &                         menv(1),menv(2),renv(1),renv(2),
+     &                         ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                         bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                         epoch(2),bhspin(1),bhspin(2))
+               endif
                vwind2 = 2.d0*beta*acc1*mass(k)/radx(k)
                omv2 = (1.d0 + vorb2/vwind2)**(3.d0/2.d0)
                dmt(3-k) = ivsqm*acc2*dmr(k)*((acc1*mass(3-k)/vwind2)**2)

--- a/cosmic/src/mlwind.f
+++ b/cosmic/src/mlwind.f
@@ -24,6 +24,8 @@
 *      stars=3.
 * Must be one of these values or mlwind will cause problem with code,
 * i.e. mlwind not set (see last line of main if statement...).
+      beasor = 0.0
+
       if(windflag.eq.0)then
 * BSE
 *
@@ -201,14 +203,15 @@
 * Optional flag (windflag < 0)
          if(windflag.lt.0.or.windflag.eq.5)then
 *	 write(*,*) 'Checking Lum and Temp for Beasor'
-	    if((lum.gt.1.0d+04.and.log10(lum).lt.5.5).and.teff.le.7.5d+03.
-     &	    and.kw.lt.5.and.kw.gt.1)then
+            if((lum.gt.1.0d+04.and.log10(lum).lt.5.5).and.
+     &         teff.le.7.5d+03.and.kw.lt.5.and.kw.gt.1)then
+               beasor = 1.0
                a = -26.4-0.23*mi
-	       b = windflag
-	       dms = (10.0**a)*(lum**abs(b))
+               b = windflag
+               dms = (10.0**a)*(lum**abs(b))
 *	       write(*,*) 'Beasor Winds'
-	    endif
-	 endif
+            endif
+          endif
 
          if(((windflag.eq.3.or.windflag.lt.0).or.kw.ge.2).and.kw.le.6)
      &   then

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -960,9 +960,9 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
 
     flag = "windflag"
     if flag in BSEDict.keys():
-        if BSEDict[flag] > 3:
+        if BSEDict[flag] > 5:
             raise ValueError(
-                "'{0:s}' needs to be set to an integer between 0 to 3, or a negative number (you set it to '{1:d}')".format(
+                "'{0:s}' needs to be set to an integer between 0 to 5, or a negative number (you set it to '{1:d}')".format(
                     flag, BSEDict[flag]
                 )
             )


### PR DESCRIPTION
This adds in a new value for evol type at the start of when Beasor applied [17] and when it stops [18] so that we can easily access in the bpp!
It also fixes a utils error_check problem with windflag > 3